### PR TITLE
Initialize EnsekError exception properly

### DIFF
--- a/ensek/client.py
+++ b/ensek/client.py
@@ -14,6 +14,7 @@ class EnsekError(Exception):
     def __init__(self, message, response):
         self.response = response
         self.message = message
+        Exception.__init__(self, message, response)
 
 
 class Ensek:


### PR DESCRIPTION
Documented here:
http://docs.celeryproject.org/en/latest/userguide/tasks.html#creating-pickleable-exceptions

To solve: https://trello.com/c/SGiiz9In

I haven't been able to get the same pickling error to happen locally.